### PR TITLE
fix: no return, check following indizes

### DIFF
--- a/src/class.dbFormHandler.php
+++ b/src/class.dbFormHandler.php
@@ -1120,7 +1120,7 @@ class dbFormHandler extends FormHandler
 					// NULL in an nullable Field is not a unique constraint error!
 					if (isset($value) && !array_key_exists($field, $notnull) && $value == "NULL")
 					{
-					    return true; 
+					    continue; 
 					}
 					
 					$where = $this->_getWhereClause( '<>', $extra );


### PR DESCRIPTION
fixed a bug

a nullable-check hides following mistakes cause following indizes will not be checked