### PR TITLE
fix: class.jsDateTextField.php (Try II)

### DIFF
--- a/src/fields/class.jsDateTextField.php
+++ b/src/fields/class.jsDateTextField.php
@@ -25,7 +25,7 @@ class jsDateTextField extends DateTextField
      * @author Thomas Branius
      * @since 16-03-2010
      */
-	public function __construct( &$oForm, $sName, $sMask = null, $bParseOtherPresentations = false, $bIncludeJS )
+	public function __construct( &$oForm, $sName, $sMask = null, $bParseOtherPresentations = false, $bIncludeJS = true )
 	{
 		parent::__construct( $oForm, $sName, $sMask, $bParseOtherPresentations);
 		


### PR DESCRIPTION
fix: PHP Deprecated:  Required parameter $bIncludeJS follows optional parameter $sMask